### PR TITLE
Bugfixes

### DIFF
--- a/jude_add_frames.pro
+++ b/jude_add_frames.pro
@@ -70,6 +70,7 @@
 ;JM: Dec. 23, 2017: Change in limits of xoff and yoff. Should not affect much,
 ;JM: Dec. 25, 2017: Using ref_frame from parameters.
 ;JM: Jam. 03, 2018: Fixed out of bounds error.
+;KS: Nov, 16, 2018: Corrected bug in Pixel time calculation.
 ;Copyright 2016 Jayant Murthy
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
@@ -236,7 +237,7 @@ endif
 			yindex = round(yoff[ielem]-yoff_start)
 			
 			if ((xindex ne old_xindex) or (yindex ne old_yindex))then begin
-				pixel_time = pixel_time + ishft*shft_times
+				pixel_time = pixel_time + (ishft+1)*shft_times
 				shft_times =shift(times, xindex, yindex)
 				if (xindex gt 0)then shft_times[0:(xindex-1) < (gxsize - 1),*] = 0
 				if (xindex lt 0)then shft_times[(gxsize + xindex) > 0:gxsize - 1, *] = 0

--- a/jude_driver_uv.pro
+++ b/jude_driver_uv.pro
@@ -383,7 +383,7 @@ if (do_not_do_this eq 0)then begin
 		endif else begin
 ;************NOTE THAT THE /NOTIMES WILL BE REMOVED FOR FINAL PRODUCTION********
 			flat_version = "No flat fielding done "
-			distort_version = "No distortion correction done
+			distort_version = "No distortion correction done"
 			sxaddhist, flat_version, out_hdr
 			sxaddhist, distort_version, out_hdr
 		endelse			

--- a/jude_fix_astrometry.pro
+++ b/jude_fix_astrometry.pro
@@ -335,7 +335,7 @@ ans=""
 				print,"Select star in the left image."
 				cursor,xstar,ystar,/dev & xstar = xstar*resolution & ystar = ystar*resolution
 				star_found = check_star_position(new_im, xstar, ystar,new_max_value)
-				print,"Is star ok?
+				print,"Is star ok?"
 				read,ans
 			endif
 
@@ -492,7 +492,7 @@ begin_corr:
 				ref_ystar = ystar
 			endif else begin
 				if (abs(dref - dnew) ge 5)then begin
-					print,"Distance is ",abs(dref - dnew)," pixels.
+					print,"Distance is ",abs(dref - dnew)," pixels."
 					read,"Are you sure? (default is y)",ans
 					if (ans eq "")then ans = 'y'
 					if (ans eq 'y')then begin

--- a/jude_interactive.pro
+++ b/jude_interactive.pro
@@ -50,6 +50,7 @@
 ;	JM: Jan  03, 2018 : Added option to reset offsets
 ;	JM: Jan. 16, 2018 : Interface changes.
 ;	JM: Jan. 20, 2018 : Added median filter to offsets.
+;   KS: Nov, 01, 2018 : Modified check_params such that boxsize can be edited. Also made ans_val long to avoid overflow errors.
 ;Copyright 2016 Jayant Murthy
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
@@ -137,8 +138,8 @@ function check_params, params
 			print,i," ",tgs[i]," ",params.(i)
 		print,"Parameter to change?"
 		read,"-1 to continue, -2 to exit, -3 to debug: ",ans_no
-		if ((ans_no ge 0) and (ans_no le 6))then begin
-			ans_val = 0
+		if ((ans_no ge 0) and (ans_no le 6)) or (ans_no eq 9))then begin
+			ans_val = 0l
 			read,"New value?",ans_val
 			params.(ans_no) = ans_val
 		endif


### PR DESCRIPTION
* Some missing quotation marks
* Some minor bugs in the interface of modifying parameters in check_params in jude_interactive:
  * It was not possible to edit boxsize from this place.
  * Entering a large integer value (which are valid for MAXFRAME) was causing overflow errors. Fixed by making the input variable a long.
* Pixel time was not being calculated correctly. This showed as a discrepancy in the EXP_TIME value in the header and the value of most pixels on the exposure map, apart from that which can be explained by difference in the methods of calculation of the two things (this difference is < 1 s).